### PR TITLE
Link to CoreGraphics framework

### DIFF
--- a/metal-flow/CMakeLists.txt
+++ b/metal-flow/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(benchmark
     PRIVATE
         "-framework Metal"
         "-framework Foundation"
+        "-framework CoreGraphics"
 )
 
 # Specify the include directories


### PR DESCRIPTION
This is necessary to run Metal on macOS (https://developer.apple.com/documentation/metal/mtlcreatesystemdefaultdevice()?changes=_4_1_2___2_1&language=objc#discussion)